### PR TITLE
Fixed Storage and Tagging Issues

### DIFF
--- a/src/main/java/seedu/address/commons/events/model/AddressBookChangedEvent.java
+++ b/src/main/java/seedu/address/commons/events/model/AddressBookChangedEvent.java
@@ -17,7 +17,6 @@ public class AddressBookChangedEvent extends BaseEvent {
         return "number of persons " + data.getPersonList().size()
                 + ", number of tags " + data.getTagList().size()
                 + ", number of appointments " + data.getAppointmentList().size()
-                + ", number of pet patients " + data.getPetPatientList().size()
-                + ", number of pet patient tags " + data.getPetPatientTagList().size();
+                + ", number of pet patients " + data.getPetPatientList().size();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -176,7 +176,7 @@ public class AddCommandParser implements Parser<AddCommand> {
     public AddCommand createNewApptforExistingOwnerAndPet(String apptInfo, String ownerNric, String petName)
             throws ParseException {
         Appointment appt = parseAppointment(apptInfo);
-        return new AddCommand(appt, new Nric(ownerNric), new PetPatientName(petName));
+        return new AddCommand(appt, new Nric(ownerNric.trim()), new PetPatientName(petName.trim()));
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -33,9 +33,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     private final UniquePersonList persons;
     private final UniqueTagList tags;
     private final UniqueAppointmentList appointments;
-    private final UniqueTagList appointmentTags;
     private final UniquePetPatientList petPatients;
-    private final UniqueTagList petPatientTags;
 
         /*
          * The 'unusual' code block below is an non-static initialization block, sometimes used to avoid duplication
@@ -47,9 +45,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons = new UniquePersonList();
         tags = new UniqueTagList();
         appointments = new UniqueAppointmentList();
-        appointmentTags = new UniqueTagList();
         petPatients = new UniquePetPatientList();
-        petPatientTags = new UniqueTagList();
     }
 
     public AddressBook() {
@@ -77,16 +73,8 @@ public class AddressBook implements ReadOnlyAddressBook {
         this.appointments.setAppointments(appointments);
     }
 
-    public void setAppointmentTags(Set<Tag> appointmentTags) {
-        this.appointmentTags.setTags(appointmentTags);
-    }
-
     public void setPetPatients(List<PetPatient> petPatients) throws DuplicatePetPatientException {
         this.petPatients.setPetPatients(petPatients);
-    }
-
-    public void setPetPatientTags(Set<Tag> petPatientTags) {
-        this.petPatientTags.setTags(petPatientTags);
     }
 
     /**
@@ -105,7 +93,7 @@ public class AddressBook implements ReadOnlyAddressBook {
             throw new AssertionError("AddressBooks should not have duplicate persons");
         }
 
-        setAppointmentTags(new HashSet<>(newData.getAppointmentTagList()));
+        setTags(new HashSet<>(newData.getTagList()));
         List<Appointment> syncedAppointmentList = newData.getAppointmentList().stream()
                 .map(this::syncWithAppointmentMasterTagList)
                 .collect(Collectors.toList());
@@ -115,7 +103,7 @@ public class AddressBook implements ReadOnlyAddressBook {
             throw new AssertionError("AddressBook should not have appointments on the same slot");
         }
 
-        setPetPatientTags(new HashSet<>(newData.getPetPatientTagList()));
+        setTags(new HashSet<>(newData.getTagList()));
         List<PetPatient> syncedPetPatientList = newData.getPetPatientList().stream()
                 .map(this::syncWithMasterTagList)
                 .collect(Collectors.toList());
@@ -225,7 +213,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     private PetPatient syncWithMasterTagList (PetPatient petPatient) {
         final UniqueTagList currentPetPatientTags = new UniqueTagList(petPatient.getTags());
-        petPatientTags.mergeFrom(currentPetPatientTags);
+        tags.mergeFrom(currentPetPatientTags);
 
         // Create map with values = tag object references in the master list
         // used for checking person tag references
@@ -287,8 +275,8 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     /**
      * Adds a pet patient to the address book.
-     * Also checks the new pet patient's tags and updates {@link #petPatientTags} with any new tags found,
-     * and updates the Tag objects in the pet patient to point to those in {@link #petPatientTags}.
+     * Also checks the new pet patient's tags and updates {@link #tags} with any new tags found,
+     * and updates the Tag objects in the pet patient to point to those in {@link #tags}.
      *
      * @throws DuplicatePetPatientException if an equivalent person already exists.
      */
@@ -301,14 +289,6 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     public void addTag(Tag t) throws UniqueTagList.DuplicateTagException {
         tags.add(t);
-    }
-
-    public void addPetPatientTag(Tag t) throws UniqueTagList.DuplicateTagException {
-        petPatientTags.add(t);
-    }
-
-    public void addAppointmentTag(Tag t) throws UniqueTagList.DuplicateTagException {
-        appointmentTags.add(t);
     }
 
     /**
@@ -355,11 +335,9 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public String toString() {
         return persons.asObservableList().size() + " persons, "
-                + tags.asObservableList().size() + " tags, "
-                + appointments.asObservableList().size() + " appointments, "
-                + appointmentTags.asObservableList().size() + " appointment tags, "
                 + petPatients.asObservableList().size() + " pet patients, "
-                + petPatientTags.asObservableList().size() + " pet patient tags";
+                + appointments.asObservableList().size() + " appointments, "
+                + tags.asObservableList().size() + " tags";
         // TODO: refine later
     }
 
@@ -379,18 +357,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
-    public ObservableList<Tag> getAppointmentTagList() {
-        return appointmentTags.asObservableList();
-    }
-
-    @Override
     public ObservableList<PetPatient> getPetPatientList() {
         return petPatients.asObservableList();
-    }
-
-    @Override
-    public ObservableList<Tag> getPetPatientTagList() {
-        return petPatientTags.asObservableList();
     }
 
     @Override
@@ -398,16 +366,14 @@ public class AddressBook implements ReadOnlyAddressBook {
         return other == this // short circuit if same object
                 || (other instanceof AddressBook // instanceof handles nulls
                 && this.persons.equals(((AddressBook) other).persons)
-                && this.tags.equalsOrderInsensitive(((AddressBook) other).tags))
                 && this.appointments.equals(((AddressBook) other).appointments)
-                && this.appointmentTags.equals(((AddressBook) other).appointmentTags)
                 && this.petPatients.equals(((AddressBook) other).petPatients)
-                && this.petPatientTags.equalsOrderInsensitive(((AddressBook) other).petPatientTags);
+                && this.tags.equalsOrderInsensitive(((AddressBook) other).tags));
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(persons, tags, appointments, appointmentTags, petPatients, petPatientTags);
+        return Objects.hash(persons, appointments, petPatients, tags);
     }
 }

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -32,22 +32,8 @@ public interface ReadOnlyAddressBook {
 
     /**
 
-     * Returns an unmodifiable view of the appointment tag list.
-     * This list will not contain any duplicate appointment tags.
-     */
-    ObservableList<Tag> getAppointmentTagList();
-
-    /**
-
      * Returns an unmodifiable view of the pet patient list.
      * This list will not contain any duplicate pet patients.
      */
     ObservableList<PetPatient> getPetPatientList();
-
-    /**
-
-     * Returns an unmodifiable view of the pet patient tags list.
-     * This list will not contain any duplicate pet patient tags.
-     */
-    ObservableList<Tag> getPetPatientTagList();
 }

--- a/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableAddressBook.java
@@ -25,8 +25,6 @@ public class XmlSerializableAddressBook {
     private List<XmlAdaptedAppointment> appointments;
     @XmlElement
     private List<XmlAdaptedPetPatient> petPatients;
-    @XmlElement
-    private List<XmlAdaptedTag> petPatientTags;
 
     /**
      * Creates an empty XmlSerializableAddressBook.
@@ -37,7 +35,6 @@ public class XmlSerializableAddressBook {
         tags = new ArrayList<>();
         appointments = new ArrayList<>();
         petPatients = new ArrayList<>();
-        petPatientTags = new ArrayList<>();
     }
 
     /**
@@ -52,8 +49,6 @@ public class XmlSerializableAddressBook {
         appointments.addAll(src.getAppointmentList().stream().map(XmlAdaptedAppointment::new)
                 .collect(Collectors.toList()));
         petPatients.addAll(src.getPetPatientList().stream().map(XmlAdaptedPetPatient::new)
-                .collect(Collectors.toList()));
-        petPatientTags.addAll(src.getPetPatientTagList().stream().map(XmlAdaptedTag::new)
                 .collect(Collectors.toList()));
     }
 
@@ -77,9 +72,6 @@ public class XmlSerializableAddressBook {
         for (XmlAdaptedPetPatient pp : petPatients) {
             addressBook.addPetPatient(pp.toModelType());
         }
-        for (XmlAdaptedTag pt : petPatientTags) {
-            addressBook.addPetPatientTag(pt.toModelType());
-        }
         return addressBook;
     }
 
@@ -97,7 +89,6 @@ public class XmlSerializableAddressBook {
         return persons.equals(otherAb.persons)
                 && tags.equals(otherAb.tags)
                 && appointments.equals(otherAb.appointments)
-                && petPatients.equals(otherAb.petPatients)
-                && petPatientTags.equals(otherAb.petPatientTags);
+                && petPatients.equals(otherAb.petPatients);
     }
 }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -41,7 +41,6 @@ public class AddressBookTest {
         assertEquals(Collections.emptyList(), addressBook.getPersonList());
         assertEquals(Collections.emptyList(), addressBook.getTagList());
         assertEquals(Collections.emptyList(), addressBook.getAppointmentList());
-        assertEquals(Collections.emptyList(), addressBook.getAppointmentTagList());
     }
 
     @Test
@@ -143,18 +142,8 @@ public class AddressBookTest {
         }
 
         @Override
-        public ObservableList<Tag> getAppointmentTagList() {
-            return appointmentTags;
-        }
-
-        @Override
         public ObservableList<PetPatient> getPetPatientList() {
             return petPatients;
-        }
-
-        @Override
-        public ObservableList<Tag> getPetPatientTagList() {
-            return petPatientTags;
         }
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalPetPatients.java
+++ b/src/test/java/seedu/address/testutil/TypicalPetPatients.java
@@ -14,7 +14,7 @@ public class TypicalPetPatients {
             .withColour("Brown and White")
             .withBloodType("O")
             .withOwnerNric(TypicalPersons.BOB.getNric().toString())
-            .withTags("Injured").build();
+            .withTags(new String[]{}).build();
 
     public static final PetPatient JEWEL = new PetPatientBuilder()
             .withName("Jewel")
@@ -23,7 +23,7 @@ public class TypicalPetPatients {
             .withColour("Calico")
             .withBloodType("AB")
             .withOwnerNric(TypicalPersons.ALICE.getNric().toString())
-            .withTags(new String[]{}).build();
+            .withTags("Depression", "Test").build();
 
     private TypicalPetPatients() {}
 }


### PR DESCRIPTION
Commit Summary:

- Removed code that causes storage of tags to be bugged
- Also resolves the issue where the storage file suddenly becomes empty upon restarting the application
- Relevant code for JUnit testing have also been updated
- Added fix from @Aquarinte for adding of appointments (see `AddCommandParser.java`)

Note: the current implementation stores all tags inside a single tag list instead of having separate tag lists for the different objects (PetPatient, Appointment and Person). Both Appointments and PetPatients are verified to work seamlessly as I have tested rather extensively. For bugs that I have discovered during testing, please refer to Issue #81.

Refers to #67.
Fixes #52, #45.