### PR TITLE
Implemented Edit Command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -169,8 +169,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parseAppointment(String appointmentInfo) throws ParseException {
         requireNonNull(appointmentInfo);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(appointmentInfo, PREFIX_DATE, PREFIX_REMARK, PREFIX_NRIC,
-                        PREFIX_NAME, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(appointmentInfo, PREFIX_DATE, PREFIX_REMARK, PREFIX_TAG);
 
         Index index;
 
@@ -182,14 +181,14 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         EditAppointmentDescriptor editAppointmentDescriptor = new EditAppointmentDescriptor();
         try {
-            ParserUtil.parsePetPatientName(argMultimap.getValue(PREFIX_NAME))
-                    .ifPresent(editAppointmentDescriptor::setPetPatientName);
+            // ParserUtil.parsePetPatientName(argMultimap.getValue(PREFIX_NAME))
+            //        .ifPresent(editAppointmentDescriptor::setPetPatientName);
             ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATE))
                     .ifPresent(editAppointmentDescriptor::setLocalDateTime);
             ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK))
                     .ifPresent(editAppointmentDescriptor::setRemark);
-            ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC))
-                    .ifPresent(editAppointmentDescriptor::setOwnerNric);
+            //ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC))
+            //        .ifPresent(editAppointmentDescriptor::setOwnerNric);
             parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG))
                     .ifPresent(editAppointmentDescriptor::setTags);
         } catch (IllegalValueException ive) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,5 +1,7 @@
 package seedu.address.model;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -52,6 +54,12 @@ public interface Model {
     void updatePerson(Person target, Person editedPerson)
             throws DuplicatePersonException, PersonNotFoundException;
 
+    void updatePetPatient(PetPatient target, PetPatient editedPetPatient)
+            throws DuplicatePetPatientException, PetPatientNotFoundException;
+
+    void updateAppointment(Appointment target, Appointment editedAppointment)
+            throws DuplicateAppointmentException, AppointmentNotFoundException;
+
     /** Removes the specific {@code tag} from all {@code persons} with that tag **/
     void deleteTag(Tag tag);
 
@@ -89,6 +97,14 @@ public interface Model {
     Person getPersonWithNric(Nric ownerNric);
 
     PetPatient getPetPatientWithNricAndName(Nric ownerNric, PetPatientName petPatientName);
+
+    ArrayList<PetPatient> getPetPatientsWithNric(Nric ownerNric);
+
+    ArrayList<Appointment> getAppointmentsWithNric(Nric ownerNric);
+
+    ArrayList<Appointment> getAppointmentsWithNricAndPetName(Nric ownerNric, PetPatientName petPatientName);
+
+    Appointment getClashingAppointment(LocalDateTime dateTime);
 
     /** Deletes the given pet. */
     void deletePetPatient(PetPatient target)

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -3,6 +3,8 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -139,6 +141,69 @@ public class ModelManager extends ComponentManager implements Model {
         return null;
     }
 
+    //@@author chialejing
+    @Override
+    public ArrayList<PetPatient> getPetPatientsWithNric(Nric ownerNric) {
+        ArrayList<PetPatient> petPatientArrayList = new ArrayList<>();
+        for (PetPatient p : addressBook.getPetPatientList()) {
+            if (p.getOwner().equals(ownerNric)) {
+                petPatientArrayList.add(p);
+            }
+        }
+        return petPatientArrayList;
+    }
+
+    @Override
+    public ArrayList<Appointment> getAppointmentsWithNric(Nric ownerNric) {
+        ArrayList<Appointment> appointmentArrayList = new ArrayList<>();
+        for (Appointment a : addressBook.getAppointmentList()) {
+            if (a.getOwnerNric().equals(ownerNric)) {
+                appointmentArrayList.add(a);
+            }
+        }
+        return appointmentArrayList;
+    }
+
+    @Override
+    public ArrayList<Appointment> getAppointmentsWithNricAndPetName(Nric ownerNric, PetPatientName petPatientName) {
+        ArrayList<Appointment> appointmentArrayList = new ArrayList<>();
+        for (Appointment a : addressBook.getAppointmentList()) {
+            if (a.getOwnerNric().equals(ownerNric) && a.getPetPatientName().equals(petPatientName)) {
+                appointmentArrayList.add(a);
+            }
+        }
+        return appointmentArrayList;
+    }
+
+    @Override
+    public Appointment getClashingAppointment(LocalDateTime dateTime) {
+        for (Appointment a : addressBook.getAppointmentList()) {
+            if (a.getDateTime().equals(dateTime)) {
+                return a;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void updatePetPatient(PetPatient target, PetPatient editedPetPatient)
+            throws DuplicatePetPatientException, PetPatientNotFoundException {
+        requireAllNonNull(target, editedPetPatient);
+
+        addressBook.updatePetPatient(target, editedPetPatient);
+        indicateAddressBookChanged();
+    }
+
+    @Override
+    public void updateAppointment(Appointment target, Appointment editedAppointment)
+            throws DuplicateAppointmentException, AppointmentNotFoundException {
+        requireAllNonNull(target, editedAppointment);
+
+        addressBook.updateAppointment(target, editedAppointment);
+        indicateAddressBookChanged();
+    }
+
+    //@@author
     @Override
     public void updatePerson(Person target, Person editedPerson)
             throws DuplicatePersonException, PersonNotFoundException {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -339,6 +340,42 @@ public class AddCommandTest {
         public void updatePerson(Person target, Person editedPerson)
                 throws DuplicatePersonException {
             fail("This method should not be called.");
+        }
+
+        @Override
+        public void updatePetPatient(PetPatient target, PetPatient editedPetPatient)
+                throws DuplicatePetPatientException {
+            fail("This method should not be called.");
+        }
+
+        @Override
+        public void updateAppointment(Appointment target, Appointment editedAppointment)
+                throws DuplicateAppointmentException {
+            fail("This method should not be called.");
+        }
+
+        @Override
+        public ArrayList<PetPatient> getPetPatientsWithNric(Nric ownerNric) {
+            fail("This method should not be called.");
+            return null;
+        }
+
+        @Override
+        public ArrayList<Appointment> getAppointmentsWithNric(Nric ownerNric) {
+            fail("This method should not be called.");
+            return null;
+        }
+
+        @Override
+        public ArrayList<Appointment> getAppointmentsWithNricAndPetName(Nric ownerNric, PetPatientName petPatientName) {
+            fail("This method should not be called.");
+            return null;
+        }
+
+        @Override
+        public Appointment getClashingAppointment(LocalDateTime dateTime) {
+            fail("This method should not be called.");
+            return null;
         }
 
         @Override


### PR DESCRIPTION
Summary:

- Editing pet patients and appointments are now supported
- Relevant dependencies will be resolved as well

Note: editing of owner's NRIC and pet patient name in appointment is disallowed, since it does not make any sense to edit from there.

Please refer to Issue #87 for more information if required. Run-through of the logic is explained in greater detail there.

Fixes #118 
Fixes #119 