### PR TITLE
Update autocomplete 

### DIFF
--- a/src/main/java/seedu/address/ui/Autocomplete.java
+++ b/src/main/java/seedu/address/ui/Autocomplete.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SPECIES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
@@ -25,8 +26,15 @@ import seedu.address.commons.events.model.AddressBookChangedEvent;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.HistoryCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RedoCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.CliSyntax;
 
 //@@author aquarinte
@@ -42,6 +50,7 @@ public class Autocomplete {
     private Logic logic;
     private String trimmedCommandInput;
     private String[] trimmedCommandInputArray;
+    private String commandWord;
     private String option;
     private String targetWord;
     private Set<String> tagSet;
@@ -76,6 +85,7 @@ public class Autocomplete {
         // split string, but retain all whitespaces in array "trimmedCommandInputArray"
         trimmedCommandInputArray = trimmedCommandInput.split("((?<= )|(?= ))", -1);
 
+        commandWord = trimmedCommandInputArray[0];
         targetWord = trimmedCommandInputArray[trimmedCommandInputArray.length - 1].toLowerCase();
         setOption();
 
@@ -112,15 +122,57 @@ public class Autocomplete {
                 return getTagSuggestions();
             }
 
-            if (targetWord.startsWith("-")) {
+            if (hasOptionsAndPrefixes() && targetWord.startsWith("-")) {
                 return getOptionSuggestions();
             }
 
-            return getPrefixSuggestions();
+            if (hasOptionsAndPrefixes()) {
+                return getPrefixSuggestions();
+            }
 
         } else {
-            return getPrefixSuggestions();
+
+            if (hasOptionsAndPrefixes()) {
+                return getPrefixSuggestions();
+            }
         }
+
+        return new ArrayList<String>();
+    }
+
+    /**
+     * Returns false if the command is one that does not require any options or prefixes in its syntax.
+     */
+    private boolean hasOptionsAndPrefixes() {
+        if (commandWord.equals(ClearCommand.COMMAND_WORD)) {
+            return false;
+        }
+
+        if (commandWord.equals(ListCommand.COMMAND_WORD)) {
+            return false;
+        }
+
+        if (commandWord.equals(ExitCommand.COMMAND_WORD)) {
+            return false;
+        }
+
+        if (commandWord.equals(UndoCommand.COMMAND_WORD)) {
+            return false;
+        }
+
+        if (commandWord.equals(RedoCommand.COMMAND_WORD)) {
+            return false;
+        }
+
+        if (commandWord.equals(HelpCommand.COMMAND_WORD)) {
+            return false;
+        }
+
+        if (commandWord.equals(HistoryCommand.COMMAND_WORD)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -130,12 +182,12 @@ public class Autocomplete {
      * Returns false if the command input is to add a new person.
      */
     private boolean hasAddCommandReferNric() {
-        if (trimmedCommandInputArray[0].equals(AddCommand.COMMAND_WORD)
+        if (commandWord.equals(AddCommand.COMMAND_WORD)
                 && trimmedCommandInputArray[2].equals(OPTION_OWNER)) {
             return false;
         }
 
-        if (trimmedCommandInputArray[0].equals(AddCommand.COMMAND_WORD)
+        if (commandWord.equals(AddCommand.COMMAND_WORD)
                 && trimmedCommandInputArray[trimmedCommandInputArray.length - 3].equals(OPTION_OWNER)
                 && targetWord.startsWith(PREFIX_NRIC.toString())) {
             return true;
@@ -150,7 +202,7 @@ public class Autocomplete {
      * Returns true if editing the owner's nric of a pet patient.
      */
     private boolean hasEditCommandReferNric() {
-        if (trimmedCommandInputArray[0].equals(EditCommand.COMMAND_WORD)
+        if (commandWord.equals(EditCommand.COMMAND_WORD)
                 && option.equals(OPTION_PETPATIENT)
                 && targetWord.startsWith(PREFIX_NRIC.toString())) {
             return true;
@@ -165,7 +217,7 @@ public class Autocomplete {
      * Returns true if finding a person by nric.
      */
     private boolean hasFindCommandReferNric() {
-        if (trimmedCommandInputArray[0].equals(FindCommand.COMMAND_WORD)
+        if (commandWord.equals(FindCommand.COMMAND_WORD)
                 && option.equals(OPTION_OWNER) && targetWord.startsWith(PREFIX_NRIC.toString())) {
             return true;
         }
@@ -183,25 +235,25 @@ public class Autocomplete {
      */
     private boolean hasReferenceToExistingPetPatientNames() {
         // Add new pet patient
-        if (trimmedCommandInputArray[0].equals(AddCommand.COMMAND_WORD)
+        if (commandWord.equals(AddCommand.COMMAND_WORD)
                 && trimmedCommandInputArray[2].equals(OPTION_PETPATIENT)
                 && targetWord.startsWith(PREFIX_NAME.toString())) {
             return false;
         }
 
         // Add new owner, new pet patient & new appointment
-        if (trimmedCommandInputArray[0].equals(AddCommand.COMMAND_WORD)
+        if (commandWord.equals(AddCommand.COMMAND_WORD)
                 && trimmedCommandInputArray[2].equals(OPTION_OWNER)
                 && trimmedCommandInputArray[trimmedCommandInputArray.length - 3].equals(OPTION_PETPATIENT)
                 && targetWord.startsWith(PREFIX_NAME.toString())) {
             return false;
         }
 
-        if (trimmedCommandInputArray[0].equals(EditCommand.COMMAND_WORD)) {
+        if (commandWord.equals(EditCommand.COMMAND_WORD)) {
             return false;
         }
 
-        if (trimmedCommandInputArray[0].equals(FindCommand.COMMAND_WORD)) {
+        if (commandWord.equals(FindCommand.COMMAND_WORD)) {
             return false;
         }
 

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -198,7 +198,7 @@ public class CommandBox extends UiPart<Region> {
 
     //@@author aquarinte
     /**
-     * Sets and shows the elements of ContextMenu {@code suggestionBox} with autocomplete suggestions.
+     * Calls Autocomplete class to process commandTextField's content.
      *
      * @param newValue New user input.
      */
@@ -209,15 +209,23 @@ public class CommandBox extends UiPart<Region> {
 
             suggestions = autocompleteLogic.getSuggestions(commandTextField);
 
-            for (String s : suggestions) {
-                MenuItem m = new MenuItem(s);
-                String autocompleteValue = StringUtil.removeDescription(s);
-                m.setOnAction(event -> handleAutocompleteSelection(autocompleteValue));
-                suggestionBox.getItems().add(m);
+            if (!suggestions.isEmpty()){
+                setContextMenu();
             }
-
-            suggestionBox.show(commandTextField, Side.BOTTOM, 0, 0);
         }
+    }
+
+    /**
+     * Sets the context menu {@code suggestionBox} with autocomplete suggestions.
+     */
+    private void setContextMenu() {
+        for (String s : suggestions) {
+            MenuItem m = new MenuItem(s);
+            String autocompleteValue = StringUtil.removeDescription(s);
+            m.setOnAction(event -> handleAutocompleteSelection(autocompleteValue));
+            suggestionBox.getItems().add(m);
+        }
+        suggestionBox.show(commandTextField, Side.BOTTOM, 0, 0);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -209,7 +209,7 @@ public class CommandBox extends UiPart<Region> {
 
             suggestions = autocompleteLogic.getSuggestions(commandTextField);
 
-            if (!suggestions.isEmpty()){
+            if (!suggestions.isEmpty()) {
                 setContextMenu();
             }
         }

--- a/src/test/java/seedu/address/ui/CommandBoxTest.java
+++ b/src/test/java/seedu/address/ui/CommandBoxTest.java
@@ -205,6 +205,19 @@ public class CommandBoxTest extends GuiUnitTest {
     }
 
     @Test
+    public void commandBox_commandNoAutocompleteOptionAndPrefix() {
+        testAutocompleteForUserInput("clear ", -1, "n", 1, "");
+        testAutocompleteForUserInput("clear ", -1, "-", 1, "");
+        testAutocompleteForUserInput("list ", -1, " n", 1, "");
+        testAutocompleteForUserInput("list ", -1, "-", 1, "");
+        testAutocompleteForUserInput("exit ", -1, "n", 1, "");
+        testAutocompleteForUserInput("exit ", -1, "-", 1, "");
+        testAutocompleteForUserInput("help ", -1, "n", 1, "");
+        testAutocompleteForUserInput("help ", -1, "-", 1, "");
+
+    }
+
+    @Test
     public void commandBox_autocompleteOption() {
         testAutocompleteForUserInput("delete ", -1, "-", 3, "delete -fa");
         testAutocompleteForUserInput("delete ", -1, "-", 4, "delete -fo");
@@ -383,6 +396,14 @@ public class CommandBoxTest extends GuiUnitTest {
                 "add -a t/checkup");
         testAutocompleteForUserInput("add -a ", -1, "t/", 2,
                 "add -a t/vaccination");
+
+        // no option: all tags
+        testAutocompleteForUserInput("add ", -1, "t/", 2,
+                "add t/checkup");
+        testAutocompleteForUserInput("add ", -1, "t/", 3,
+                "add t/depression");
+        testAutocompleteForUserInput("add ", -1, "t/", 5,
+                "add t/owesMoney");
     }
 
     @Test


### PR DESCRIPTION
Autocomplete will not show options and prefixes suggestions after these command words:
- list
- help
- history
- undo
- redo
- clear
- exit

Because these commands do not require prefixes or options.

#93 