### PR TITLE
Implemented Checks for Edit Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -110,7 +110,6 @@ public class EditCommand extends UndoableCommand {
     public static final String MESSAGE_PAST_APPOINTMENT = "Appointment cannot be in the past.";
     public static final String MESSAGE_CONCURRENT_APPOINTMENT = "Appointment cannot be concurrent "
             + "with other appointments.";
-    
     /**
      * Enum to support the type of edit command that the user wishes to execute.
      */


### PR DESCRIPTION
Important bug fix:
- causes Medeina to hang; unable to load medeina.xml when unresolved
- after fix, any appointments with concurrency, same date time or date time in the past will be checked for
- relevant error messages will be thrown out

Fixes #176 

Note: the displaying of appointments has already been fixed in another PR.